### PR TITLE
change Base URL construction

### DIFF
--- a/src/controllers/upload-controller.ts
+++ b/src/controllers/upload-controller.ts
@@ -1,5 +1,5 @@
 export async function uploadLenses(data: string, domain: string): Promise<Response> {
-    const baseUrl = `${domain}/ips/api/fhir/Library`;
+    const baseUrl = `${domain}/fhir/Library`;
 
     const dataJson = JSON.parse(data);
 

--- a/src/controllers/upload-controller.ts
+++ b/src/controllers/upload-controller.ts
@@ -1,5 +1,5 @@
 export async function uploadLenses(data: string, domain: string): Promise<Response> {
-    const baseUrl = `${domain}/fhir/Library`;
+    const baseUrl = `${domain}/Library`;
 
     const dataJson = JSON.parse(data);
 


### PR DESCRIPTION
correct base url to work correctly for gravitate and work for other server as well. The provide server should be the FHIR endpoint.

For gravitate (dev) should be https://gravitate-health.lst.tfo.upm.es/epi/api/fhir